### PR TITLE
refactor(topgrade): Ignore container update failures

### DIFF
--- a/dotfiles/topgrade/.config/topgrade.toml
+++ b/dotfiles/topgrade/.config/topgrade.toml
@@ -4,7 +4,7 @@
 
 [misc]
 assume_yes = true
-ignore_failures = ["system"]
+ignore_failures = ["containers"]
 cleanup = true
 
 [windows]


### PR DESCRIPTION
Often I do not have the docker daemon docker running, so the container update will fail.