### PR TITLE
feat(nix): Add stable nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -302,6 +302,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1737973256,
+        "narHash": "sha256-IJDRjMOYzh1DATVeMD3aUY9dee69xGJ2/DZvSiqUqrY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b4d23f5bfc0cfaabf7677d836f100ec44138f139",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "deploy-rs": "deploy-rs",
@@ -317,6 +333,7 @@
         "nix-darwin": "nix-darwin",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs?ref=release-24.11";
     nix-darwin = {
       url = "github:LnL7/nix-darwin?ref=master";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/nixos/presets/nix.nix
+++ b/nix/modules/nixos/presets/nix.nix
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: 0BSD
 {
+  inputs,
   lib,
   pkgs,
   ...
@@ -14,6 +15,20 @@
       channel.enable = lib.mkDefault false;
 
       package = pkgs.nixVersions.stable;
+
+      registry = {
+        nixpkgs-stable = {
+          exact = true;
+          from = {
+            type = "indirect";
+            id = "nixpkgs-stable";
+          };
+          to = {
+            type = "path";
+            path = inputs.nixpkgs-stable;
+          };
+        };
+      };
 
       settings = {
         auto-allocate-uids = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (lib.mkDefault true);


### PR DESCRIPTION
Allows easy running of packages from stable: `nix run nixpkgs-stable#committed`.